### PR TITLE
roundPlayerListPing to same 6 levels vanilla displays

### DIFF
--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/AttrHider.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/AttrHider.java
@@ -7,6 +7,7 @@ import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.reflect.StructureModifier;
 import com.comphenix.protocol.wrappers.EnumWrappers;
 import com.comphenix.protocol.wrappers.Pair;
+import com.comphenix.protocol.wrappers.PlayerInfoData;
 import com.comphenix.protocol.wrappers.WrappedWatchableObject;
 import com.destroystokyo.paper.MaterialTags;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
@@ -26,6 +27,9 @@ import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public final class AttrHider extends BasicHack {
 
 	public static final String BYPASS_PERMISSION = "attrhider.bypass";
@@ -40,6 +44,9 @@ public final class AttrHider extends BasicHack {
 
 	@AutoLoad
 	private boolean hideHealth;
+
+	@AutoLoad
+	private boolean roundPlayerListPing;
 
 	public AttrHider(final SimpleAdminHacks plugin, final BasicHackConfig config) {
 		super(plugin, config);
@@ -152,6 +159,41 @@ public final class AttrHider extends BasicHack {
 				}
 			});
 		}
+		if (this.roundPlayerListPing) {
+			this.packets.addAdapter(new PacketAdapter(this.plugin, PacketType.Play.Server.PLAYER_INFO) {
+				@Override
+				public void onPacketSending(final PacketEvent event) {
+					final PacketContainer packet = event.getPacket();
+					final Player player = event.getPlayer();
+					if (player.hasPermission(BYPASS_PERMISSION)) {
+						return;
+					}
+					final PacketContainer cloned = packet.deepClone();
+					List<PlayerInfoData> newInfos = new ArrayList<>();
+					List<PlayerInfoData> oldInfos = cloned.getPlayerInfoDataLists().read(0);
+					for (PlayerInfoData oldInfo : oldInfos) {
+						int latency = oldInfo.getLatency();
+						// Limit player ping in the tablist to the same 6 values vanilla clients can discern visually
+						// this follows 1.16.5 PlayerTabOverlay#renderPingIcon()
+						if (latency < 0) latency = -1;
+						else if (latency < 150) latency = 75; // average of 0 and 150, arbitrary
+						else if (latency < 300) latency = 225;
+						else if (latency < 600) latency = 450;
+						else if (latency < 1000) latency = 800;
+						else latency = 1000;
+						newInfos.add(new PlayerInfoData(
+								oldInfo.getProfile(),
+								latency,
+								oldInfo.getGameMode(),
+								oldInfo.getDisplayName()));
+					}
+					cloned.getPlayerInfoDataLists().write(0, newInfos);
+					// The packet data is shared between events, but the event
+					// instance is exclusive to THIS sending of the packet
+					event.setPacket(cloned);
+				}
+			});
+		}
 	}
 
 	@Override
@@ -177,5 +219,4 @@ public final class AttrHider extends BasicHack {
 				|| material == Material.LINGERING_POTION
 				|| material == Material.SPLASH_POTION;
 	}
-	
 }

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -62,6 +62,8 @@ hacks:
     hideEffects: true
     # Hide the health of entities
     hideHealth: true
+    # Limit player ping in the tablist to the same 6 values vanilla clients can discern visually
+    roundPlayerListPing: true
   AutoRespawn:
     enabled: true
     # Delay in MS


### PR DESCRIPTION
Should fix for both the player itself and other players, and both variants of the tablist update packets that contain ping values.

Mods that display ping as number now only display one of the six hardcoded values; vanilla still shows the same bars textures it was showing previously, for all actual ping values.

Port of https://github.com/CivClassic/SimpleAdminHacks/pull/93