### PR TITLE
Prevent Bound Armour being repaired via Crafting

### DIFF
--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/ArmourBound.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/ArmourBound.java
@@ -106,7 +106,7 @@ public class ArmourBound extends BasicHack {
 		if (boundItem == null) {
 			return;
 		}
-		inventory.setResult(new ItemStack(Material.AIR));
+		inventory.setResult(null);
 		for (HumanEntity viewer : inventory.getViewers()) {
 			if (viewer instanceof final Player playerViewer) {
 				playerViewer.updateInventory();

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/ArmourBound.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/ArmourBound.java
@@ -12,8 +12,11 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -69,6 +72,43 @@ public class ArmourBound extends BasicHack {
 			newItem.setAmount(0);
 			player.getWorld().dropItemNaturally(player.getLocation(), toDrop);
 			player.sendMessage(Component.text("This armor is not bound to you!").color(NamedTextColor.RED));
+		}
+	}
+
+	@EventHandler
+	public void onItemCraft(PrepareItemCraftEvent event) {
+		CraftingInventory inventory = event.getInventory();
+		ItemStack[] matrix = inventory.getMatrix();
+		if (event.getRecipe() == null) {
+			return;
+		}
+		ItemStack boundItem = null;
+		PersistentDataContainer container = null;
+		ItemMeta meta = null;
+		for (ItemStack item : matrix) {
+			if (item == null) {
+				continue;
+			}
+			if (!whitelist.contains(item.getType().toString())) {
+				continue;
+			}
+			if (!item.hasItemMeta()) {
+				continue;
+			}
+			meta = item.getItemMeta();
+			container = meta.getPersistentDataContainer();
+			if (!container.has(this.key, PersistentDataType.STRING)) {
+				continue;
+			}
+			boundItem = item;
+			break;
+		}
+		if (boundItem == null || container == null) {
+			return;
+		}
+		inventory.setResult(new ItemStack(Material.AIR));
+		for (HumanEntity player : inventory.getViewers()) {
+			((Player) player).updateInventory();
 		}
 	}
 

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/ArmourBound.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/ArmourBound.java
@@ -77,11 +77,11 @@ public class ArmourBound extends BasicHack {
 
 	@EventHandler
 	public void onItemCraft(PrepareItemCraftEvent event) {
-		CraftingInventory inventory = event.getInventory();
-		ItemStack[] matrix = inventory.getMatrix();
 		if (event.getRecipe() == null) {
 			return;
 		}
+		CraftingInventory inventory = event.getInventory();
+		ItemStack[] matrix = inventory.getMatrix();
 		ItemStack boundItem = null;
 		PersistentDataContainer container = null;
 		ItemMeta meta = null;
@@ -92,10 +92,10 @@ public class ArmourBound extends BasicHack {
 			if (!whitelist.contains(item.getType().toString())) {
 				continue;
 			}
-			if (!item.hasItemMeta()) {
+			meta = item.getItemMeta();
+			if (meta == null) {
 				continue;
 			}
-			meta = item.getItemMeta();
 			container = meta.getPersistentDataContainer();
 			if (!container.has(this.key, PersistentDataType.STRING)) {
 				continue;
@@ -103,12 +103,14 @@ public class ArmourBound extends BasicHack {
 			boundItem = item;
 			break;
 		}
-		if (boundItem == null || container == null) {
+		if (boundItem == null) {
 			return;
 		}
 		inventory.setResult(new ItemStack(Material.AIR));
-		for (HumanEntity player : inventory.getViewers()) {
-			((Player) player).updateInventory();
+		for (HumanEntity viewer : inventory.getViewers()) {
+			if (viewer instanceof final Player playerViewer) {
+				playerViewer.updateInventory();
+			}
 		}
 	}
 


### PR DESCRIPTION
PrepareItemCraftEvent doesn't give us a usable result when asking for the Recipes result, therefore we cannot support ArmourBound armour being repaired initially. This implementation could make the result be the ArmourBound item + the durability acquired in repair however is open to allowing enchanted items to be repaired if done, hence the decision to just make the result AIR