### PR TITLE
Disable Grindstone use so they can be placed as decorative blocks

### DIFF
--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
@@ -18,6 +18,7 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 	private boolean isPhantomSpawning;
 	private boolean enderChestPlacement;
 	private boolean enderChestUse;
+    private boolean grindstoneUse;
 	private boolean shulkerBoxUse;
 	private boolean totemPowers;
 	private boolean chorusFruitUse;
@@ -61,6 +62,9 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 
 		this.enderChestUse = config.getBoolean("enderChestUse", false);
 		if (!this.enderChestUse) plugin().log("  Using EnderChests is disabled");
+		
+		this.grindstoneUse = config.getBoolean("grindstoneUse", false);
+		if (!this.grindstoneUse) plugin().log("  Using Grindstones is disabled");
 
 		this.shulkerBoxUse = config.getBoolean("shulkerBoxUse", false);
 		if (!this.shulkerBoxUse) plugin().log("  Using Shulker Boxes is disabled");
@@ -131,6 +135,10 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 
 	public boolean isEnderChestUse() {
 		return this.enderChestUse;
+	}
+	
+	public boolean isGrindstoneUse() {
+		return this.grindstoneUse;
 	}
 
 	public boolean isShulkerBoxUse() {

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
@@ -155,7 +155,14 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 			} else {
 				genStatus.append("disabled\n");
 			}
-
+			
+			genStatus.append("  Grindstone use is ");
+			if (config.isGrindstoneUse()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+			
 			genStatus.append("  Shulker Box use is ");
 			if (config.isShulkerBoxUse()) {
 				genStatus.append("enabled\n");
@@ -312,6 +319,20 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 			boolean enderChest = action == Action.RIGHT_CLICK_BLOCK &&
 					Material.ENDER_CHEST.equals(material);
 			if (enderChest) {
+				event.setCancelled(true);
+			}
+		}
+	}
+	
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void disableGrindstoneUse(PlayerInteractEvent event) {
+		if (!config.isEnabled()) return;
+		if (!config.isGrindstoneUse()) {
+			Action action = event.getAction();
+			Material material = event.getClickedBlock().getType();
+			boolean Grindstone = action == Action.RIGHT_CLICK_BLOCK &&
+					Material.GRINDSTONE.equals(material);
+			if (Grindstone) {
 				event.setCancelled(true);
 			}
 		}


### PR DESCRIPTION
Copied the existing functionality for Enderchests in GameFeatures over to Grindstones so they can be removed from the block placement blacklist