### PR TITLE
Overhauling OTT

### DIFF
--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     compileOnly("net.civmc.combattagplus:paper:2.0.0-SNAPSHOT:dev")
     compileOnly("net.civmc.banstick:banstick-paper:2.0.1:dev")
 	compileOnly("net.civmc.bastion:bastion-paper:3.0.1:dev")
-	// TODO: Add ExilePearl dependency once its added to CivMC Maven repo
+	compileOnly("net.civmc.exilepearl:exilepearl-paper:2.1.3:dev")
 
 	compileOnly("com.comphenix.protocol:ProtocolLib:4.8.0")
 

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     compileOnly("net.civmc.combattagplus:paper:2.0.0-SNAPSHOT:dev")
     compileOnly("net.civmc.banstick:banstick-paper:2.0.1:dev")
 	compileOnly("net.civmc.bastion:bastion-paper:3.0.1:dev")
+	// TODO: Add ExilePearl dependency once its added to CivMC Maven repo
 
 	compileOnly("com.comphenix.protocol:ProtocolLib:4.8.0")
 

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/SimpleAdminHacks.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/SimpleAdminHacks.java
@@ -38,8 +38,9 @@ public class SimpleAdminHacks extends ACivMod {
 			setEnabled(false);
 			return;
 		}
-		this.manager.loadAllHacks();
 		this.commands = new CommandRegistrar(this);
+		this.manager.loadAllHacks();
+		this.manager.enableAllHacks();
 	}
 
 	@Override

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/OneTimeTeleportConfig.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/OneTimeTeleportConfig.java
@@ -20,6 +20,7 @@ public final class OneTimeTeleportConfig extends SimpleHackConfig {
 	private List<Material> materialBlacklist;
 	private List<Material> unsafeMaterials;
 	private long timeLimitOnUsage;
+	private boolean limitToSameWorld;
 
 	public OneTimeTeleportConfig(
 			final @NotNull SimpleAdminHacks plugin,
@@ -58,6 +59,8 @@ public final class OneTimeTeleportConfig extends SimpleHackConfig {
 				.toList();
 		// Parse maximum time limit to use OTT
 		this.timeLimitOnUsage = ConfigHelper.parseTime(config.getString("ott_timeout", "2d"));
+		// Parse same-world limit
+		this.limitToSameWorld = config.getBoolean("limitToSameWorld", false);
 	}
 
 	public @NotNull List<Material> getMaterialBlacklist() {
@@ -70,5 +73,9 @@ public final class OneTimeTeleportConfig extends SimpleHackConfig {
 
 	public long getTimeLimitOnUsageInMillis() {
 		return this.timeLimitOnUsage;
+	}
+
+	public boolean isLimitingToSameWorld() {
+		return this.limitToSameWorld;
 	}
 }

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/OneTimeTeleportConfig.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/OneTimeTeleportConfig.java
@@ -2,63 +2,73 @@ package com.programmerdan.minecraft.simpleadminhacks.configs;
 
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHackConfig;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.config.ConfigHelper;
+import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.civmodcore.inventory.items.MaterialUtils;
+import vg.civcraft.mc.civmodcore.utilities.CivLogger;
 
-public class OneTimeTeleportConfig extends SimpleHackConfig {
+public final class OneTimeTeleportConfig extends SimpleHackConfig {
 
-	//private List<String> itemBlacklistString;
+	private final CivLogger LOGGER = CivLogger.getLogger(OneTimeTeleportConfig.class);
+
 	private List<Material> materialBlacklist;
 	private List<Material> unsafeMaterials;
-	private long timelimitOnUsage;
+	private long timeLimitOnUsage;
 
-	public OneTimeTeleportConfig(SimpleAdminHacks plugin,
-								 ConfigurationSection base) {super(plugin, base);
+	public OneTimeTeleportConfig(
+			final @NotNull SimpleAdminHacks plugin,
+			final @NotNull ConfigurationSection config
+	) {
+		super(plugin, config);
 	}
 
 	@Override
-	protected void wireup(ConfigurationSection config) {
-		List<String> itemBlacklistString = config.getStringList("material_blacklist");
-		if (itemBlacklistString.isEmpty()) {
-			plugin().getLogger().warning("material_blacklist was empty? is this an error?");
-		}
-		this.materialBlacklist = new ArrayList<>();
-		for (String s : itemBlacklistString) {
-			Material material = Material.matchMaterial(s);
-			if (material == null) {
-				plugin().getLogger().warning("Material " + s + " in item black list for OTT couldn't be matched, skipping but is this a typo?");
-				continue;
-			}
-			materialBlacklist.add(material);
-		}
-
-
-		this.unsafeMaterials = new ArrayList<>();
-		List<String> unsafeMaterialsString = config.getStringList("unsafe_materials");
-		for (String s : unsafeMaterialsString) {
-			Material material = Material.matchMaterial(s);
-			if (material == null) {
-				plugin().getLogger().warning("Material " + s + " in unsafe materials list for OTT couldn't be matched, skipping but is this a typo?");
-				continue;
-			}
-			materialBlacklist.add(material);
-		}
-		this.timelimitOnUsage = ConfigHelper.parseTime(config.getString("ott_timeout", "2d"));
+	protected void wireup(final ConfigurationSection config) {
+		// Parse blacklisted item materials
+		this.materialBlacklist = config.getStringList("material_blacklist")
+				.stream()
+				.map((raw) -> {
+					final Material material = MaterialUtils.getMaterial(raw);
+					if (!ItemUtils.isValidItemMaterial(material)) {
+						LOGGER.warning("Blacklisted material [" + raw + "] is not a valid item material!");
+						return null;
+					}
+					return material;
+				})
+				.filter(Objects::nonNull)
+				.toList();
+		// Parse unsafe blocks
+		this.unsafeMaterials = config.getStringList("unsafe_materials")
+				.stream()
+				.map((raw) -> {
+					final Material material = MaterialUtils.getMaterial(raw);
+					if (material == null || !material.isBlock()) {
+						LOGGER.warning("Unsafe material [" + raw + "] is not a valid block material!");
+						return null;
+					}
+					return material;
+				})
+				.filter(Objects::nonNull)
+				.toList();
+		// Parse maximum time limit to use OTT
+		this.timeLimitOnUsage = ConfigHelper.parseTime(config.getString("ott_timeout", "2d"));
 	}
 
-	public List<Material> getMaterialBlacklist() {
-		return Collections.unmodifiableList(materialBlacklist);
+	public @NotNull List<Material> getMaterialBlacklist() {
+		return Collections.unmodifiableList(Objects.requireNonNullElseGet(this.materialBlacklist, List::of));
 	}
 
-	public List<Material> getUnsafeMaterials() {
-		return Collections.unmodifiableList(unsafeMaterials);
+	public @NotNull List<Material> getUnsafeMaterials() {
+		return Collections.unmodifiableList(Objects.requireNonNullElseGet(this.unsafeMaterials, List::of));
 	}
 
-	public long getTimelimitOnUsageInMillis() {
-		return timelimitOnUsage;
+	public long getTimeLimitOnUsageInMillis() {
+		return this.timeLimitOnUsage;
 	}
 }

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/OneTimeTeleportConfig.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/OneTimeTeleportConfig.java
@@ -2,7 +2,6 @@ package com.programmerdan.minecraft.simpleadminhacks.configs;
 
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHackConfig;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.bukkit.Material;
@@ -64,11 +63,11 @@ public final class OneTimeTeleportConfig extends SimpleHackConfig {
 	}
 
 	public @NotNull List<Material> getMaterialBlacklist() {
-		return Collections.unmodifiableList(Objects.requireNonNullElseGet(this.materialBlacklist, List::of));
+		return Objects.requireNonNullElseGet(this.materialBlacklist, List::of);
 	}
 
 	public @NotNull List<Material> getUnsafeMaterials() {
-		return Collections.unmodifiableList(Objects.requireNonNullElseGet(this.unsafeMaterials, List::of));
+		return Objects.requireNonNullElseGet(this.unsafeMaterials, List::of);
 	}
 
 	public long getTimeLimitOnUsageInMillis() {

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/framework/HackManager.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/framework/HackManager.java
@@ -124,12 +124,7 @@ public final class HackManager {
 		}
 		register(hack);
 		this.plugin.info("Registered hack: " + hackName);
-		interactWithHack(hack, (finalHack) -> {
-			finalHack.onLoad();
-			if (finalHack.shouldEnable()) {
-				finalHack.enable();
-			}
-		});
+		interactWithHack(hack, SimpleHack::onLoad);
 		return hack;
 	}
 

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/OneTimeTeleport.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/OneTimeTeleport.java
@@ -4,6 +4,7 @@ import co.aikar.commands.BaseCommand;
 import co.aikar.commands.BukkitCommandCompletionContext;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.Default;
+import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.bukkit.contexts.OnlinePlayer;
 import com.google.common.collect.Lists;
@@ -104,15 +105,21 @@ public final class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> imp
 				final Player sender
 		) {
 			if (checkOTT(sender.getUniqueId())) {
-				sender.sendMessage(Component.text("Your one time teleport will expire in " + TextUtil.formatDuration(
-						config().getTimeLimitOnUsageInMillis() - (System.currentTimeMillis() - OneTimeTeleport.this.timeSinceGranted.getValue(sender.getUniqueId()))
-				), NamedTextColor.GREEN));
+				final long expiresIn = config().getTimeLimitOnUsageInMillis() - (System.currentTimeMillis() - OneTimeTeleport.this.timeSinceGranted.getValue(sender.getUniqueId()));
+				sender.sendMessage(Component.text()
+						.content("Your one time teleport will expire in " + TextUtil.formatDuration(expiresIn))
+						.color(NamedTextColor.GREEN)
+						.decorate(TextDecoration.UNDERLINED)
+						.hoverEvent(HoverEvent.showText(Component.text("Clicking this message will suggest an OTT request command")))
+						.clickEvent(ClickEvent.suggestCommand("/ott to "))
+				);
 				return;
 			}
-			sender.sendMessage(Component.text("You don't have a one time teleport.", NamedTextColor.RED));
+			sender.sendMessage(Component.text("You don't have a one-time teleport.", NamedTextColor.RED));
 		}
 
 		@Subcommand("to|request")
+		@Description("Makes an OTT request to a player. If accepted, you'll teleport to them.")
 		public void requestOTT(
 				final Player sender,
 				final OnlinePlayer targetPlayer
@@ -167,6 +174,7 @@ public final class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> imp
 		}
 
 		@Subcommand("revoke|rescind|stop")
+		@Description("Revokes your OTT request.")
 		public void rescindRequest(
 				final Player sender
 		) {
@@ -198,6 +206,7 @@ public final class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> imp
 
 		@Subcommand("accept|approve|allow|yes")
 		@CommandCompletion("@sah_ott_requests")
+		@Description("Accepts an OTT request to your location.")
 		public void acceptOTT(
 				final Player sender,
 				final OnlinePlayer requestingOnlinePlayer
@@ -257,6 +266,7 @@ public final class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> imp
 
 		@Subcommand("reject|refuse|deny|no")
 		@CommandCompletion("@sah_ott_requests")
+		@Description("Rejects an OTT to your location.")
 		public void rejectOTT(
 				final Player sender,
 				final OnlinePlayer requestingOnlinePlayer

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/OneTimeTeleport.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/OneTimeTeleport.java
@@ -1,190 +1,306 @@
 package com.programmerdan.minecraft.simpleadminhacks.hacks;
 
-import com.destroystokyo.paper.event.player.PlayerInitialSpawnEvent;
+import co.aikar.commands.BaseCommand;
+import co.aikar.commands.BukkitCommandCompletionContext;
+import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.Default;
+import co.aikar.commands.annotation.Subcommand;
+import co.aikar.commands.bukkit.contexts.OnlinePlayer;
+import com.google.common.collect.Lists;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.configs.OneTimeTeleportConfig;
 import com.programmerdan.minecraft.simpleadminhacks.framework.SimpleHack;
-
-import java.util.*;
-
 import isaac.bastion.Bastion;
 import isaac.bastion.BastionBlock;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.UUID;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.ComponentBuilder;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.bukkit.*;
+import net.minelink.ctplus.CombatTagPlus;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.block.Block;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
-import org.spigotmc.event.player.PlayerSpawnLocationEvent;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import vg.civcraft.mc.civmodcore.commands.NamedCommand;
+import vg.civcraft.mc.civmodcore.commands.TabComplete;
+import vg.civcraft.mc.civmodcore.players.settings.PlayerSetting;
 import vg.civcraft.mc.civmodcore.players.settings.PlayerSettingAPI;
 import vg.civcraft.mc.civmodcore.players.settings.impl.BooleanSetting;
 import vg.civcraft.mc.civmodcore.players.settings.impl.LongSetting;
 import vg.civcraft.mc.civmodcore.utilities.TextUtil;
 
-public class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> implements CommandExecutor {
+public final class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> implements Listener {
 
-	private BooleanSetting hasOTT;
-	private LongSetting timeSinceGranted;
-	private final Map<UUID, UUID> senderToReciever;
-
-	public OneTimeTeleport(SimpleAdminHacks plugin, OneTimeTeleportConfig config) {
+	public OneTimeTeleport(
+			final @NotNull SimpleAdminHacks plugin,
+			final @NotNull OneTimeTeleportConfig config
+	) {
 		super(plugin, config);
-		this.senderToReciever = new HashMap<>();
 	}
 
-	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-		if (!(sender instanceof Player player)) {
-			sender.sendMessage(ChatColor.AQUA + "Old school command sender!, Go away console, this is players only");
-			return true;
-		}
-		// /ott should return if you can ott
-		// /ott <player> should request ott
-		// /ott revoke should cancel a request
-		// /ott accept <player> should do teleport if valid ott request
-		switch (args.length) {
-			case 0:
-				if(!this.checkOTT(player.getUniqueId())){
-					player.sendMessage(Component.text("You don't have a one time teleport.", NamedTextColor.RED));
-				}else{
-					//TextUtil.formatDuration()
-					long time = this.config.getTimelimitOnUsageInMillis() - (System.currentTimeMillis() - this.timeSinceGranted.getValue(player.getUniqueId()));
-					player.sendMessage(Component.text("Your one time teleport will expire in " + TextUtil.formatDuration(time), NamedTextColor.GREEN));
-				}
-				return true;
-			case 1:
-
-				if (args[0].equalsIgnoreCase("revoke")) {
-					if (!this.senderToReciever.containsKey(player.getUniqueId())) {
-						player.sendMessage(Component.text("You have no active OTT requests", NamedTextColor.RED));
-						return true;
-					}
-					this.hasOTT.setValue(player.getUniqueId(), true);
-					this.senderToReciever.remove(player.getUniqueId());
-					player.sendMessage(Component.text("You have revoked your OTT request!", NamedTextColor.GREEN));
-					return true;
-				}
-
-				if(!this.checkOTT(player.getUniqueId())){
-					// ott has expired, add message
-					player.sendMessage(Component.text("Your one-time teleport has expired!"));
-					return true;
-				}
-
-				Player target = Bukkit.getPlayer(args[0]);
-				if (target == null) {
-					player.sendMessage(Component.text("The player " + args[0] + " does not exist or isn't online!", NamedTextColor.RED));
-					return true;
-				}
-
-				if (this.senderToReciever.containsKey(player.getUniqueId())) {
-					player.sendMessage(Component.text("Revoke your existing request first!", NamedTextColor.RED));
-					return true;
-				}
-
-				if (!this.hasOTT.getValue(player.getUniqueId())) {
-					player.sendMessage(Component.text("You have already used your OTT!", NamedTextColor.RED));
-					return true;
-				}
-				player.sendMessage(Component.text("You have requested to teleport to " + target.getName() + "!", NamedTextColor.GREEN));
-				requestOTT(player.getUniqueId(), target.getUniqueId());
-
-				String commandStr = "/ott accept " + player.getName();
-
-				Component msg = Component.text(player.getName() + " has requested to teleport to you! ", NamedTextColor.GREEN)
-						.append(
-								Component.text("Click me or type /ott accept " + player.getName() + " to accept!",
-												NamedTextColor.DARK_GREEN,
-												TextDecoration.BOLD)
-										.clickEvent(ClickEvent.runCommand(commandStr))
-										.hoverEvent(HoverEvent.showText(Component.text(commandStr)))
-						);
-
-				target.sendMessage(msg);
-				return true;
-			case 2:
-				if (args[0].equalsIgnoreCase("accept")) {
-					Player targetPlayer = Bukkit.getPlayer(args[1]);
-					if (targetPlayer == null) {
-						player.sendMessage(Component.text("The player " + args[1] + " does not exist or isn't online!", NamedTextColor.RED));
-						return true;
-					}
-
-					if(!this.senderToReciever.containsKey(targetPlayer.getUniqueId()) ||
-							!this.senderToReciever.get(targetPlayer.getUniqueId()).equals(player.getUniqueId())){
-						player.sendMessage(Component.text("There are no active requests from that player!", NamedTextColor.RED));
-						return true;
-					}
-
-					if(!this.checkOTT(targetPlayer.getUniqueId())){
-						// ott has expired, add message
-						player.sendMessage(Component.text(targetPlayer.getName()+"'s one-time teleport has expired!"));
-						targetPlayer.sendMessage(Component.text("Failed to teleport because your one-time teleport has expired!"));
-						this.senderToReciever.remove(targetPlayer.getUniqueId());
-						return true;
-					}
-
-					if(!this.isSafeLocation(player, targetPlayer)){
-						player.sendMessage(Component.text("This isn't a safe location to accept a one-time teleport!"));
-						targetPlayer.sendMessage(Component.text(player.getName() + " tried to accept your one-time teleport in an unsafe location!"));
-						return true;
-					}
-
-
-					/*
-					long timeJoined = targetPlayer.getFirstPlayed();
-					if (System.currentTimeMillis() > (timeJoined + config.getTimelimitOnUsageInMillis())) {
-						targetPlayer.sendMessage(Component.text("You have ran out of time to use your one time teleport!"));
-						this.hasOTT.setValue(targetPlayer.getUniqueId(), false);
-						return true;
-					}
-					 */
-
-					removeBlacklistItems(targetPlayer.getInventory());
-					targetPlayer.sendMessage(Component.text("You may find some items missing after teleporting, these were removed as they are blacklisted to be teleported with!", NamedTextColor.AQUA));
-					targetPlayer.teleport(player.getLocation());
-					player.sendMessage(Component.text(targetPlayer.getName() + " has been teleported to you!", NamedTextColor.GREEN));
-					this.invalidate(targetPlayer.getUniqueId());
-					return true;
-				}
-			default:
-				return false;
-		}
+	public static @NotNull OneTimeTeleportConfig generate(
+			final @NotNull SimpleAdminHacks plugin,
+			final @NotNull ConfigurationSection config
+	) {
+		return new OneTimeTeleportConfig(plugin, config);
 	}
 
-	public void requestOTT(UUID sender, UUID reciever) {
-		this.senderToReciever.put(sender, reciever);
-		//this.hasOTT.setValue(sender, false);
+	@Override
+	public void onEnable() {
+		// Since there's no way to unregister settings without some gnarly reflection, this will only register settings
+		// that aren't already registered. Also, MoreCollectionUtils.getMissing() when?
+		final Collection<PlayerSetting<?>> allSettings = PlayerSettingAPI.getAllSettings();
+		final Collection<PlayerSetting<?>> ourSettings = Lists.newArrayList(this.hasOTT, this.timeSinceGranted);
+		ourSettings.removeIf(allSettings::contains);
+		ourSettings.forEach((setting) -> PlayerSettingAPI.registerSetting(setting, null));
+
+		plugin().registerListener(this);
+		plugin().getCommands().registerCommand(this.commands);
 	}
 
-	public void removeBlacklistItems(Inventory inventory) {
-		for (ItemStack is : inventory.getContents()) {
-			if (is == null || is.getType() == Material.AIR) {
-				continue;
+	@Override
+	public void onDisable() {
+		plugin().getCommands().unregisterCommand(this.commands);
+		HandlerList.unregisterAll(this);
+	}
+
+	private final Map<UUID, UUID> senderToReceiver = new TreeMap<>();
+
+	private final BooleanSetting hasOTT = new BooleanSetting(
+			plugin(),
+			false,
+			"Can you use a one time teleport?",
+			"hasOTT",
+			"Allows usage of /ott to <player>"
+	);
+
+	private final LongSetting timeSinceGranted = new LongSetting(
+			plugin(),
+			-1L,
+			"Time since OTT granted",
+			"timeSinceOTTGrant"
+	);
+
+	private final BaseCommand commands = new NamedCommand("ott") {
+		@Default
+		public void defaultCommand(
+				final Player sender
+		) {
+			if (checkOTT(sender.getUniqueId())) {
+				sender.sendMessage(Component.text("Your one time teleport will expire in " + TextUtil.formatDuration(
+						config().getTimeLimitOnUsageInMillis() - (System.currentTimeMillis() - OneTimeTeleport.this.timeSinceGranted.getValue(sender.getUniqueId()))
+				), NamedTextColor.GREEN));
+				return;
 			}
-			if (this.config.getMaterialBlacklist().contains(is.getType())) {
-				inventory.remove(is);
+			sender.sendMessage(Component.text("You don't have a one time teleport.", NamedTextColor.RED));
+		}
+
+		@Subcommand("to|request")
+		public void requestOTT(
+				final Player sender,
+				final OnlinePlayer targetPlayer
+		) {
+			if (!checkOTT(sender.getUniqueId())) {
+				sender.sendMessage(Component.text("Your one-time teleport has expired!"));
+				return;
+			}
+
+			if (!OneTimeTeleport.this.hasOTT.getValue(sender.getUniqueId())) {
+				sender.sendMessage(Component.text("You have already used your OTT!", NamedTextColor.RED));
+				return;
+			}
+
+			if (GLUE_isCombatTagged(sender.getUniqueId())) {
+				sender.sendMessage(Component.text("You cannot OTT while in combat!", NamedTextColor.RED));
+				return;
+			}
+
+			final UUID previousRequest = OneTimeTeleport.this.senderToReceiver.put(
+					sender.getUniqueId(),
+					targetPlayer.getPlayer().getUniqueId()
+			);
+
+			if (previousRequest != null) {
+				final Player previousTargetPlayer = Bukkit.getPlayer(previousRequest);
+				if (previousTargetPlayer != null) {
+					previousTargetPlayer.sendMessage(Component.text(sender.getName() + " has rescinded their OTT request to you.", NamedTextColor.GREEN));
+				}
+			}
+
+			sender.sendMessage(Component.text("You have requested to teleport to " + targetPlayer.getPlayer().getName() + "!", NamedTextColor.GREEN));
+
+			final String commandStr = "/ott accept " + sender.getName();
+			targetPlayer.getPlayer().sendMessage(Component.text()
+					.content("Click me or type \"" + commandStr + "\" to accept!")
+					.color(NamedTextColor.DARK_GREEN)
+					.decorate(TextDecoration.BOLD, TextDecoration.UNDERLINED)
+					.hoverEvent(HoverEvent.showText(Component.text("Clicking this message will accept the OTT request")))
+					.clickEvent(ClickEvent.runCommand(commandStr))
+			);
+		}
+
+		@Subcommand("revoke|rescind|stop")
+		public void rescindRequest(
+				final Player sender
+		) {
+			final UUID targetUUID = OneTimeTeleport.this.senderToReceiver.remove(sender.getUniqueId());
+			if (targetUUID == null) {
+				sender.sendMessage(Component.text("You have no active OTT requests.", NamedTextColor.RED));
+				return;
+			}
+			sender.sendMessage(Component.text("You have revoked your OTT request!", NamedTextColor.GREEN));
+			final Player targetPlayer = Bukkit.getPlayer(targetUUID);
+			if (targetPlayer != null) {
+				targetPlayer.sendMessage(Component.text(sender.getName() + " has rescinded their OTT request to you.", NamedTextColor.GREEN));
 			}
 		}
+
+		@TabComplete("sah_ott_requests")
+		public List<String> getRequestsToMe(
+				final @NotNull BukkitCommandCompletionContext context
+		) {
+			final UUID targetPlayerUUID = context.getPlayer().getUniqueId();
+			return OneTimeTeleport.this.senderToReceiver.entrySet()
+					.stream()
+					.filter((entry) -> Objects.equals(targetPlayerUUID, entry.getValue()))
+					.map((entry) -> Bukkit.getPlayer(entry.getKey()))
+					.filter(Objects::nonNull)
+					.map(Player::getName)
+					.toList();
+		}
+
+		@Subcommand("accept|approve|allow|yes")
+		@CommandCompletion("@sah_ott_requests")
+		public void acceptOTT(
+				final Player sender,
+				final OnlinePlayer requestingOnlinePlayer
+		) {
+			final Player requestingPlayer = requestingOnlinePlayer.getPlayer();
+
+			if (!OneTimeTeleport.this.senderToReceiver.remove(
+					requestingPlayer.getUniqueId(),
+					sender.getUniqueId()
+			)) {
+				sender.sendMessage(Component.text("There are no active requests from that player!", NamedTextColor.RED));
+				return;
+			}
+
+			if (!checkOTT(requestingPlayer.getUniqueId())) {
+				sender.sendMessage(Component.text(requestingPlayer.getName() + "'s one-time teleport has expired!"));
+				requestingPlayer.sendMessage(Component.text("Failed to teleport because your one-time teleport has expired!"));
+				return;
+			}
+
+			if (GLUE_isCombatTagged(requestingPlayer.getUniqueId())) {
+				sender.sendMessage(Component.text(requestingPlayer.getName() + " could not one-time teleport as they're in combat!", NamedTextColor.RED));
+				requestingPlayer.sendMessage(Component.text(sender.getName() + " accepted your request, but you're in combat!", NamedTextColor.RED));
+				OneTimeTeleport.this.senderToReceiver.put(requestingPlayer.getUniqueId(), sender.getUniqueId()); // Be kind and put the request back!
+				return;
+			}
+
+			if (!isSafeLocation(sender, requestingPlayer)) {
+				sender.sendMessage(Component.text("This isn't a safe location to accept a one-time teleport!", NamedTextColor.RED));
+				requestingPlayer.sendMessage(Component.text(sender.getName() + " tried to accept your one-time teleport but is in an unsafe location!", NamedTextColor.RED));
+				OneTimeTeleport.this.senderToReceiver.put(requestingPlayer.getUniqueId(), sender.getUniqueId()); // Be kind and put the request back!
+				return;
+			}
+
+			// Remove any blacklisted materials from the player's inventory
+			requestingPlayer.sendMessage(Component.text("You may find some items missing after teleporting, these were removed as they are blacklisted to be teleported with!", NamedTextColor.AQUA));
+			final Inventory requestingPlayerInventory = requestingPlayer.getInventory();
+			config().getMaterialBlacklist().forEach(requestingPlayerInventory::remove);
+
+			OneTimeTeleport.this.hasOTT.setValue(requestingPlayer.getUniqueId(), false);
+
+			requestingPlayer.teleport(sender.getLocation());
+			sender.sendMessage(Component.text(requestingPlayer.getName() + " has been teleported to you!", NamedTextColor.GREEN));
+		}
+
+		@Subcommand("reject|refuse|deny|no")
+		@CommandCompletion("@sah_ott_requests")
+		public void rejectOTT(
+				final Player sender,
+				final OnlinePlayer requestingOnlinePlayer
+		) {
+			final Player requestingPlayer = requestingOnlinePlayer.getPlayer();
+
+			if (!OneTimeTeleport.this.senderToReceiver.remove(
+					requestingPlayer.getUniqueId(),
+					sender.getUniqueId()
+			)) {
+				sender.sendMessage(Component.text("There are no active requests from that player!", NamedTextColor.RED));
+				return;
+			}
+
+			requestingPlayer.sendMessage(Component.text(sender.getName() + " has denied your OTT request!", NamedTextColor.RED));
+		}
+	};
+
+	@EventHandler
+	public void onFirstJoin(final PlayerJoinEvent event) {
+		checkOTT(event.getPlayer().getUniqueId());
 	}
 
-	private List<Block> getNearbyBlocks(Block start, int radius){
-		if (radius < 0) {
+	@EventHandler
+	public void onQuit(final PlayerQuitEvent event) {
+		final Player whoQuit = event.getPlayer();
+		// Remove all pending OTT's involving this player
+		this.senderToReceiver.entrySet().removeIf((entry) -> {
+			final UUID requesterUUID = entry.getKey(), targetUUID = entry.getValue();
+
+			// The player was the target of OTT requests
+			if (Objects.equals(whoQuit.getUniqueId(), targetUUID)) {
+				final Player requesterPlayer = Bukkit.getPlayer(requesterUUID);
+				if (requesterPlayer != null) { // Just in case
+					requesterPlayer.sendMessage(Component.text("Your OTT request to " + whoQuit.getName() + " has been voided."));
+				}
+				return true;
+			}
+
+			// The player had made an OTT request
+			if (Objects.equals(whoQuit.getUniqueId(), requesterUUID)) {
+				final Player targetPlayer = Bukkit.getPlayer(targetUUID);
+				if (targetPlayer != null) { // Just in case
+					targetPlayer.sendMessage(Component.text(whoQuit.getName() + "'s OTT request has been voided."));
+				}
+			}
+			return false;
+		});
+	}
+
+	private static boolean GLUE_isCombatTagged(
+			final @NotNull UUID playerUUID
+	) {
+		final Plugin cbtPlugin = Bukkit.getPluginManager().getPlugin("CombatTagPlus");
+		return cbtPlugin != null && ((CombatTagPlus) cbtPlugin).getTagManager().isTagged(playerUUID);
+	}
+
+	private @NotNull List<Block> getNearbyBlocks(
+			final @NotNull Block start,
+			final int radius
+	) {
+		if (radius <= 0) {
 			return new ArrayList<>(0);
 		}
-		int iterations = (radius * 2) + 1;
-		List<Block> blocks = new ArrayList<>(iterations * iterations * iterations);
+		final int iterations = (radius * 2) + 1;
+		final var blocks = new ArrayList<Block>(iterations * iterations * iterations);
 		for (int x = -radius; x <= radius; x++) {
 			for (int y = -radius; y <= radius; y++) {
 				for (int z = -radius; z <= radius; z++) {
@@ -195,96 +311,47 @@ public class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> implement
 		return blocks;
 	}
 
-	private boolean isSafeLocation(Player player, Player targetPlayer){
-		if(player == null || targetPlayer == null){
-			return false;
+	private boolean isSafeLocation(
+			final @NotNull Player targetPlayer,
+			final @NotNull Player requestingPlayer
+	) {
+		final Location destination = targetPlayer.getLocation();
+
+		if (Bukkit.getPluginManager().isPluginEnabled("Bastion")) {
+			for (final BastionBlock bastion : Bastion.getBastionManager().getBlockingBastions(destination)) {
+				if (!bastion.canPlace(targetPlayer) || !bastion.canPlace(requestingPlayer)) {
+					return false;
+				}
+			}
 		}
 
-		Set<BastionBlock> bastions = Bastion.getBastionManager().getBlockingBastions(player.getLocation());
-		if(!bastions.stream().allMatch(bastion -> bastion.canPlace(player) && bastion.canPlace(targetPlayer))){
-			return false;
+		for (final Block block : getNearbyBlocks(destination.getBlock(), 8)) {
+			if (config().getUnsafeMaterials().contains(block.getType())) {
+				return false;
+			}
 		}
 
-		List<Block> blocks = this.getNearbyBlocks(player.getLocation().getBlock(), 8);
-		return blocks.stream().noneMatch(block -> this.config.getUnsafeMaterials().contains(block.getType()));
+		return true;
 	}
 
-	private void invalidate(UUID uuid){
-		this.senderToReciever.remove(uuid);
-		this.hasOTT.setValue(uuid, false);
-	}
-
-	private boolean checkOTT(UUID uuid){
-		if(uuid == null){
-			return false;
-		}
-		//UUID uuid = player.getUniqueId();
-		long timeSince = this.timeSinceGranted.getValue(uuid);
-		if(timeSince == -1L && !this.hasOTT.getValue(uuid)){
+	private boolean checkOTT(
+			final @NotNull UUID uuid
+	) {
+		final long timeSince = this.timeSinceGranted.getValue(uuid);
+		if (timeSince == -1L && !this.hasOTT.getValue(uuid)) {
 			this.hasOTT.setValue(uuid, true);
 			this.timeSinceGranted.setValue(uuid, System.currentTimeMillis());
 			return true;
-		}else if(timeSince != -1L && System.currentTimeMillis() >= (timeSince + this.config.getTimelimitOnUsageInMillis()) && this.hasOTT.getValue(uuid)){
+		}
+		else if (
+				timeSince != -1L
+						&& System.currentTimeMillis() >= (timeSince + config().getTimeLimitOnUsageInMillis())
+						&& this.hasOTT.getValue(uuid)
+		) {
 			this.hasOTT.setValue(uuid, false);
-			this.senderToReciever.remove(uuid);
+			this.senderToReceiver.remove(uuid);
 			return false;
 		}
-
 		return this.hasOTT.getValue(uuid);
-	}
-
-	@EventHandler
-	public void onFirstJoin(PlayerSpawnLocationEvent event) {
-		if (!config.isEnabled()) {
-			return;
-		}
-
-		this.checkOTT(event.getPlayer().getUniqueId());
-		/*
-		if (event.getPlayer().hasPlayedBefore()) {
-			return;
-		}
-		this.hasOTT.setValue(event.getPlayer().getUniqueId(), true);
-		 */
-	}
-
-	@Override
-	public void onEnable() {
-		super.onEnable();
-		registerSettings();
-	}
-
-	@Override
-	public void onDisable() {
-		super.onDisable();
-	}
-
-	@Override
-	public void registerCommands() {
-		if (config.isEnabled()) {
-			plugin().registerCommand("ott", this);
-		}
-	}
-
-	private void registerSettings() {
-		//Default this to false since we want to set it true if the player has logged in for the first time
-		this.hasOTT = new BooleanSetting(this.plugin,
-				false,
-				"Can you use a one time teleport?",
-				"hasOTT",
-				"Allows usage of /ott <player>");
-
-		this.timeSinceGranted = new LongSetting(this.plugin,
-				-1L,
-				"Time since OTT granted",
-				"timeSinceOTTGrant");
-
-		//We don't want to expose the setting to a players /config
-		PlayerSettingAPI.registerSetting(hasOTT, null);
-		PlayerSettingAPI.registerSetting(timeSinceGranted, null);
-	}
-
-	public static OneTimeTeleportConfig generate(SimpleAdminHacks plugin, ConfigurationSection config) {
-		return new OneTimeTeleportConfig(plugin, config);
 	}
 }

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/OneTimeTeleport.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/OneTimeTeleport.java
@@ -7,6 +7,7 @@ import co.aikar.commands.annotation.Default;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.bukkit.contexts.OnlinePlayer;
+import com.devotedmc.ExilePearl.ExilePearlPlugin;
 import com.google.common.collect.Lists;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.configs.OneTimeTeleportConfig;

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/OneTimeTeleport.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/OneTimeTeleport.java
@@ -132,6 +132,11 @@ public final class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> imp
 				return;
 			}
 
+			if (GLUE_isPearled(sender.getUniqueId())) {
+				sender.sendMessage(Component.text("You cannot OTT while pearled!", NamedTextColor.RED));
+				return;
+			}
+
 			final UUID previousRequest = OneTimeTeleport.this.senderToReceiver.put(
 					sender.getUniqueId(),
 					targetPlayer.getPlayer().getUniqueId()
@@ -215,6 +220,12 @@ public final class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> imp
 				return;
 			}
 
+			if (GLUE_isPearled(requestingPlayer.getUniqueId())) {
+				sender.sendMessage(Component.text(requestingPlayer.getName() + " could not one-time teleport as they're pearled!", NamedTextColor.RED));
+				requestingPlayer.sendMessage(Component.text(sender.getName() + " accepted your request, but you're pearled!", NamedTextColor.RED));
+				return;
+			}
+
 			if (!isSafeLocation(sender, requestingPlayer)) {
 				sender.sendMessage(Component.text("This isn't a safe location to accept a one-time teleport!", NamedTextColor.RED));
 				requestingPlayer.sendMessage(Component.text(sender.getName() + " tried to accept your one-time teleport but is in an unsafe location!", NamedTextColor.RED));
@@ -283,6 +294,15 @@ public final class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> imp
 			}
 			return false;
 		});
+	}
+
+	private static boolean GLUE_isPearled(
+			final @NotNull UUID playerUUID
+	) {
+		if (Bukkit.getPluginManager().isPluginEnabled("ExilePearl")) {
+			return ExilePearlPlugin.getApi().getPearlManager().getPearl(playerUUID) != null;
+		}
+		return false;
 	}
 
 	private static boolean GLUE_isCombatTagged(

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/OneTimeTeleport.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/OneTimeTeleport.java
@@ -137,6 +137,11 @@ public final class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> imp
 				return;
 			}
 
+			if (config().isLimitingToSameWorld() && !Objects.equals(sender.getWorld(), targetPlayer.getPlayer().getWorld())) {
+				sender.sendMessage(Component.text("You cannot OTT to another world!", NamedTextColor.RED));
+				return;
+			}
+
 			final UUID previousRequest = OneTimeTeleport.this.senderToReceiver.put(
 					sender.getUniqueId(),
 					targetPlayer.getPlayer().getUniqueId()
@@ -223,6 +228,12 @@ public final class OneTimeTeleport extends SimpleHack<OneTimeTeleportConfig> imp
 			if (GLUE_isPearled(requestingPlayer.getUniqueId())) {
 				sender.sendMessage(Component.text(requestingPlayer.getName() + " could not one-time teleport as they're pearled!", NamedTextColor.RED));
 				requestingPlayer.sendMessage(Component.text(sender.getName() + " accepted your request, but you're pearled!", NamedTextColor.RED));
+				return;
+			}
+
+			if (config().isLimitingToSameWorld() && !Objects.equals(sender.getWorld(), requestingPlayer.getWorld())) {
+				sender.sendMessage(Component.text(requestingPlayer.getName() + " could not one-time teleport as they're in a different world!", NamedTextColor.RED));
+				requestingPlayer.sendMessage(Component.text(sender.getName() + " accepted your request, but you're in a different world!", NamedTextColor.RED));
 				return;
 			}
 

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -475,6 +475,8 @@ hacks:
     unsafe_materials: [LAVA, WATER]
     # How long newfriends will have to use OTT before it expires
     ott_timeout: 2d
+    # Whether or not to limit OTT to same-world teleports
+    limitToSameWorld: false
   ReinforcedChestBreak:
     enabled: true
     # in seconds

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -467,6 +467,14 @@ hacks:
             - "This world is unforgiving."
             - "Be sure to get a good night's"
             - "rest soon."
+  OneTimeTeleport:
+    enabled: true
+    # Item materials that should be removed from the player upon teleporting
+    material_blacklist: []
+    # Blocks that will block OTT if in range of the target player
+    unsafe_materials: [LAVA, WATER]
+    # How long newfriends will have to use OTT before it expires
+    ott_timeout: 2d
   ReinforcedChestBreak:
     enabled: true
     # in seconds
@@ -500,11 +508,6 @@ hacks:
     maxHealth: 50
   TimingsHack:
     enabled: true
-  OneTimeTeleport:
-    enabled: true
-    material_blacklist: []
-    unsafe_materials: [LAVA, WATER]
-    ott_timeout: 2d
   ToggleLamp:
     enabled: false
     cooldownTime: 100

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -89,9 +89,6 @@ commands:
     usage: /<command> full.path.to.event
     permission: simpleadmin.eventdebug
   stats: {} # Defined in (basic) PlayerStats
-  ott:
-    description: Allows a player a one time teleport
-    usage: /<command> <player>
 permissions:
   simpleadmin.*:
     description: Gives access to all SimpleAdminHacks commands

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ author: ProgrammerDan
 authors: [ProgrammerDan, Maxopoly]
 version: ${version}
 depend: [CivModCore]
-softdepend: [CombatTagPlus, NameLayer, Citadel, ProtocolLib, BanStick]
+softdepend: [CombatTagPlus, NameLayer, Citadel, ProtocolLib, BanStick, ExilePearl]
 api-version: 1.18
 commands:
   hacks:

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -113,6 +113,7 @@ permissions:
       simpleadmin.debugwand: true
       simpleadmin.bedlocator: true
       simpleadmin.elytrabypass: true
+      simpleadmin.grantott: true
     simpleadmin.hacks:
       description: Allows control of the hacks and settings which simpleadminhacks supports
       default: op
@@ -160,4 +161,7 @@ permissions:
       default: true
     simpleadmin.elytrabypass:
       description: Gives the ability to bypass elytra restrictions
+      default: op
+    simpleadmin.grantott:
+      description: Gives the ability to grant players OTT usages
       default: op


### PR DESCRIPTION
This PR does the following:

- Switches to using Aikar commands.
- Added a "reject" subcommand with tab-complete to deny an OTT request.
- The "accept" subcommand now also has tab-complete.
- Moved making an OTT request to a "to" subcommand. (/ott to Orinnari) and clicking the accept-message will suggest the command rather than invoke it.
- You cannot make an OTT request, or teleport via OTT if combat tagged.
- Made the hack itself as reload-safe as possible.
- Fixed bug where OTT's time limit doesn't start ticking until you first used the command, instead of upon login.
- Voids an OTT request if the requester or the requested player logs out.
- You can no longer OTT to yourself.
