### PR TITLE
Add Map Copy Protection

### DIFF
--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MapCopyProtection.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MapCopyProtection.java
@@ -4,8 +4,7 @@ import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.TextColor;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.Command;
@@ -22,7 +21,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class MapCopyProtection extends BasicHack implements CommandExecutor {
@@ -74,24 +72,29 @@ public class MapCopyProtection extends BasicHack implements CommandExecutor {
 			event.setCancelled(true);
 			event.getWhoClicked().sendMessage(
 					Component.text()
-							.color(TextColor.color(0xFF5555))
-							.content("You can not copy copy protected maps")
+							.color(NamedTextColor.RED)
+							.content("You can not clone copy protected maps")
 			);
 		}
 	}
 
 	@Override
 	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-		Player player = Bukkit.getPlayer(sender.getName());
-
-		if (player == null) return false;
+		if (!(sender instanceof Player player)) {
+			sender.sendMessage(
+					Component.text()
+							.color(NamedTextColor.RED)
+							.content("This command can only be run by players")
+			);
+			return true;
+		}
 
 		ItemStack item = player.getInventory().getItemInMainHand();
 
 		if (item.getType() != Material.FILLED_MAP) {
 			sender.sendMessage(
 					Component.text()
-							.color(TextColor.color(0xFF5555))
+							.color(NamedTextColor.RED)
 							.content("Only filled maps can be copy protected")
 			);
 			return true; // Command failed, but was syntactically correct, so no need to tell the player how to use it
@@ -100,7 +103,7 @@ public class MapCopyProtection extends BasicHack implements CommandExecutor {
 		if (isCopy(item)) {
 			sender.sendMessage(
 					Component.text()
-							.color(TextColor.color(0xFF5555))
+							.color(NamedTextColor.RED)
 							.content("You can not copy protect copy protected maps")
 			);
 			return true; // Command failed, but was syntactically correct, so no need to tell the player how to use it
@@ -110,7 +113,7 @@ public class MapCopyProtection extends BasicHack implements CommandExecutor {
 
 		itemMeta.getPersistentDataContainer().set(copyKey, PersistentDataType.INTEGER, 1);
 
-		itemMeta.lore(new ArrayList<>(List.of(Component.text(String.format("Copy protected by %s", sender.getName())))));
+		itemMeta.lore(List.of(Component.text(String.format("Copy protected by %s", sender.getName()))));
 
 		player.getInventory().getItemInMainHand().setItemMeta(itemMeta);
 
@@ -118,9 +121,6 @@ public class MapCopyProtection extends BasicHack implements CommandExecutor {
 	}
 
 	private boolean isCopy(ItemStack item) {
-		if (item.getItemMeta().getPersistentDataContainer().has(copyKey, PersistentDataType.INTEGER)) {
-			int val = item.getItemMeta().getPersistentDataContainer().get(copyKey, PersistentDataType.INTEGER);
-			return val == 1;
-		} else return false;
+		return item.getItemMeta().getPersistentDataContainer().has(copyKey, PersistentDataType.INTEGER);
 	}
 }

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MapCopyProtection.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MapCopyProtection.java
@@ -4,7 +4,7 @@ import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -22,7 +22,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class MapCopyProtection extends BasicHack implements CommandExecutor {
@@ -74,14 +73,23 @@ public class MapCopyProtection extends BasicHack implements CommandExecutor {
 			event.setCancelled(true);
 			event.getWhoClicked().sendMessage(
 					Component.text()
-							.color(TextColor.color(0xFF5555))
-							.content("You can not copy copy protected maps")
+							.color(NamedTextColor.RED)
+							.content("You can not clone copy protected maps")
 			);
 		}
 	}
 
 	@Override
 	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+		if (!(sender instanceof Player)) {
+			sender.sendMessage(
+					Component.text()
+							.color(NamedTextColor.RED)
+							.content("This command can only be run by players")
+			);
+			return true;
+		}
+
 		Player player = Bukkit.getPlayer(sender.getName());
 
 		if (player == null) return false;
@@ -91,7 +99,7 @@ public class MapCopyProtection extends BasicHack implements CommandExecutor {
 		if (item.getType() != Material.FILLED_MAP) {
 			sender.sendMessage(
 					Component.text()
-							.color(TextColor.color(0xFF5555))
+							.color(NamedTextColor.RED)
 							.content("Only filled maps can be copy protected")
 			);
 			return true; // Command failed, but was syntactically correct, so no need to tell the player how to use it
@@ -100,7 +108,7 @@ public class MapCopyProtection extends BasicHack implements CommandExecutor {
 		if (isCopy(item)) {
 			sender.sendMessage(
 					Component.text()
-							.color(TextColor.color(0xFF5555))
+							.color(NamedTextColor.RED)
 							.content("You can not copy protect copy protected maps")
 			);
 			return true; // Command failed, but was syntactically correct, so no need to tell the player how to use it
@@ -110,7 +118,7 @@ public class MapCopyProtection extends BasicHack implements CommandExecutor {
 
 		itemMeta.getPersistentDataContainer().set(copyKey, PersistentDataType.INTEGER, 1);
 
-		itemMeta.lore(new ArrayList<>(List.of(Component.text(String.format("Copy protected by %s", sender.getName())))));
+		itemMeta.lore(List.of(Component.text(String.format("Copy protected by %s", sender.getName()))));
 
 		player.getInventory().getItemInMainHand().setItemMeta(itemMeta);
 
@@ -118,9 +126,6 @@ public class MapCopyProtection extends BasicHack implements CommandExecutor {
 	}
 
 	private boolean isCopy(ItemStack item) {
-		if (item.getItemMeta().getPersistentDataContainer().has(copyKey, PersistentDataType.INTEGER)) {
-			int val = item.getItemMeta().getPersistentDataContainer().get(copyKey, PersistentDataType.INTEGER);
-			return val == 1;
-		} else return false;
+		return item.getItemMeta().getPersistentDataContainer().has(copyKey, PersistentDataType.INTEGER);
 	}
 }

--- a/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MapCopyProtection.java
+++ b/paper/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MapCopyProtection.java
@@ -1,0 +1,126 @@
+package com.programmerdan.minecraft.simpleadminhacks.hacks.basic;
+
+import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
+import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
+import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftInventoryCrafting;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.CartographyInventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MapCopyProtection extends BasicHack implements CommandExecutor {
+	final NamespacedKey copyKey = new NamespacedKey(plugin, "copy-protected");
+
+	public MapCopyProtection(SimpleAdminHacks plugin, BasicHackConfig config) {
+		super(plugin, config);
+	}
+
+	@Override
+	public void onEnable() {
+		super.onEnable();
+		plugin().registerCommand("copyprotect", this);
+	}
+
+	@Override
+	public void onDisable() {
+		super.onDisable();
+	}
+
+	@EventHandler
+	public void onMapCopyCartography(InventoryClickEvent event) {
+		if (!(event.getInventory() instanceof CartographyInventory) || event.getSlotType() != InventoryType.SlotType.RESULT)
+			return;
+
+		ItemStack item = event.getInventory().getItem(1); // paper, glass pane, blank map slot
+
+		if (item == null) return;
+
+		if (item.getType() == Material.GLASS_PANE || item.getType() == Material.PAPER) return; // Allow locking and scaling of copy protected maps
+
+		handleCopyProtection(event);
+	}
+
+	@EventHandler
+	public void onMapCopyCrafting(InventoryClickEvent event) {
+		if (!(event.getInventory() instanceof CraftInventoryCrafting) || event.getSlotType() != InventoryType.SlotType.RESULT)
+			return;
+
+		handleCopyProtection(event);
+	}
+
+	private void handleCopyProtection(InventoryClickEvent event) {
+		ItemStack item = event.getCurrentItem();
+
+		if (item == null || item.getType() == Material.AIR) return;
+
+		if (isCopy(item)) {
+			event.setCancelled(true);
+			event.getWhoClicked().sendMessage(
+					Component.text()
+							.color(TextColor.color(0xFF5555))
+							.content("You can not copy copy protected maps")
+			);
+		}
+	}
+
+	@Override
+	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+		Player player = Bukkit.getPlayer(sender.getName());
+
+		if (player == null) return false;
+
+		ItemStack item = player.getInventory().getItemInMainHand();
+
+		if (item.getType() != Material.FILLED_MAP) {
+			sender.sendMessage(
+					Component.text()
+							.color(TextColor.color(0xFF5555))
+							.content("Only filled maps can be copy protected")
+			);
+			return true; // Command failed, but was syntactically correct, so no need to tell the player how to use it
+		}
+
+		if (isCopy(item)) {
+			sender.sendMessage(
+					Component.text()
+							.color(TextColor.color(0xFF5555))
+							.content("You can not copy protect copy protected maps")
+			);
+			return true; // Command failed, but was syntactically correct, so no need to tell the player how to use it
+		}
+
+		ItemMeta itemMeta = item.getItemMeta();
+
+		itemMeta.getPersistentDataContainer().set(copyKey, PersistentDataType.INTEGER, 1);
+
+		itemMeta.lore(new ArrayList<>(List.of(Component.text(String.format("Copy protected by %s", sender.getName())))));
+
+		player.getInventory().getItemInMainHand().setItemMeta(itemMeta);
+
+		return true;
+	}
+
+	private boolean isCopy(ItemStack item) {
+		if (item.getItemMeta().getPersistentDataContainer().has(copyKey, PersistentDataType.INTEGER)) {
+			int val = item.getItemMeta().getPersistentDataContainer().get(copyKey, PersistentDataType.INTEGER);
+			return val == 1;
+		} else return false;
+	}
+}

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -136,6 +136,8 @@ hacks:
     disableGapples: true
   ItemMetaConverterHack:
     enabled: true
+  MapCopyProtection:
+    enabled: true
   OldEnchanting:
     enabled: true
     # Hides what enchantment will be granted within the Enchanting Table

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -1,10 +1,10 @@
 name: ${name}
 main: com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks
 author: ProgrammerDan
-authors: [ ProgrammerDan, Maxopoly ]
+authors: [ProgrammerDan, Maxopoly]
 version: ${version}
-depend: [ CivModCore ]
-softdepend: [ CombatTagPlus, NameLayer, Citadel, ProtocolLib, BanStick, ExilePearl ]
+depend: [CivModCore]
+softdepend: [CombatTagPlus, NameLayer, Citadel, ProtocolLib, BanStick, ExilePearl]
 api-version: 1.18
 commands:
   hacks:
@@ -29,7 +29,7 @@ commands:
   copyprotect:
     description: Protect a map from copying.
     usage: /<command>
-    permission: simpleadmin.copyright
+    permission: simpleadmin.copyprotect
   serialize:
     description: Print to console the object held as serialized yaml
     usage: /<command>
@@ -92,7 +92,7 @@ commands:
     description: Allows debugging of an event and its handlers
     usage: /<command> full.path.to.event
     permission: simpleadmin.eventdebug
-  stats: { } # Defined in (basic) PlayerStats
+  stats: {} # Defined in (basic) PlayerStats
 permissions:
   simpleadmin.*:
     description: Gives access to all SimpleAdminHacks commands

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -1,10 +1,10 @@
 name: ${name}
 main: com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks
 author: ProgrammerDan
-authors: [ProgrammerDan, Maxopoly]
+authors: [ ProgrammerDan, Maxopoly ]
 version: ${version}
-depend: [CivModCore]
-softdepend: [CombatTagPlus, NameLayer, Citadel, ProtocolLib, BanStick, ExilePearl]
+depend: [ CivModCore ]
+softdepend: [ CombatTagPlus, NameLayer, Citadel, ProtocolLib, BanStick, ExilePearl ]
 api-version: 1.18
 commands:
   hacks:
@@ -25,7 +25,11 @@ commands:
     permission: simpleadmin.invmod
   chunklimits:
     description: Display block chunk limit in chat
-    usage: /<command> 
+    usage: /<command>
+  copyprotect:
+    description: Protect a map from copying.
+    usage: /<command>
+    permission: simpleadmin.copyright
   serialize:
     description: Print to console the object held as serialized yaml
     usage: /<command>
@@ -88,7 +92,7 @@ commands:
     description: Allows debugging of an event and its handlers
     usage: /<command> full.path.to.event
     permission: simpleadmin.eventdebug
-  stats: {} # Defined in (basic) PlayerStats
+  stats: { } # Defined in (basic) PlayerStats
 permissions:
   simpleadmin.*:
     description: Gives access to all SimpleAdminHacks commands


### PR DESCRIPTION
Maps can be copy protected by running `/copyprotect` while holding a filled map. Copy protected maps may still be locked and have their scale changed, but may not be copied in either a cartography table or a crafting table.